### PR TITLE
Adds sensible restrictions to bancounts

### DIFF
--- a/bannedWordServer/router.py
+++ b/bannedWordServer/router.py
@@ -76,7 +76,7 @@ def ban(serverid, banid):
 	result = None
 	if request.method == 'POST':
 		try:
-			result = BanRoute().post_one(session, request.headers['Authorization'], banid, request.json['banned_word'])
+			result = BanRoute().post_one(session, request.headers['Authorization'], serverid, banid, request.json['banned_word'])
 			session.commit()
 		except:
 			session.rollback()
@@ -87,7 +87,7 @@ def ban(serverid, banid):
 		result = BanRoute().get_one(session, request.headers['Authorization'], banid)
 	elif request.method == 'DELETE':
 		try:
-			BanRoute().delete(session, request.headers['Authorization'], banid)
+			BanRoute().delete(session, request.headers['Authorization'], serverid, banid)
 			result = jsonify()
 			result.status_code = 204
 			session.commit()

--- a/tests/routes/test_banroute.py
+++ b/tests/routes/test_banroute.py
@@ -4,7 +4,7 @@ from sqlalchemy.orm import sessionmaker
 from unittest import TestCase
 
 from bannedWordServer.config import BOT_TOKEN
-from bannedWordServer.constants.errors import NotFoundError, InvalidTypeError, DuplicateResourceError, AuthenticationError
+from bannedWordServer.constants.errors import ValidationError, NotFoundError, InvalidTypeError, DuplicateResourceError, AuthenticationError
 from bannedWordServer import db
 from bannedWordServer.models.server import Server
 from bannedWordServer.models.ban import Ban
@@ -16,6 +16,7 @@ engine = create_engine('sqlite:///:memory:')
 class TestBanRouteGetCollection(TestCase):
 	def setUp(self):
 		db.Model.metadata.create_all(engine)
+		self.authtoken = "Bot " + BOT_TOKEN
 		self.connection = engine.connect()
 		self.trans = self.connection.begin()
 		self.session = Session(bind=self.connection)
@@ -25,16 +26,16 @@ class TestBanRouteGetCollection(TestCase):
 		self.session.add(new_server)
 
 	def test_banroute_get_collection__bad_serverid(self):
-		self.assertRaises(InvalidTypeError, BanRoute().get_collection, self.session, "Bot " + BOT_TOKEN, "asdf")
+		self.assertRaises(InvalidTypeError, BanRoute().get_collection, self.session, self.authtoken, "asdf")
 
 	def test_banroute_get_collection__server_not_found(self):
-		self.assertRaises(NotFoundError, BanRoute().get_collection, self.session, "Bot " + BOT_TOKEN, 12345)
+		self.assertRaises(NotFoundError, BanRoute().get_collection, self.session, self.authtoken, 12345)
 
 	def test_banroute_get_collection__unauthorized(self):
 		self.assertRaises(AuthenticationError, BanRoute().get_collection, self.session, "Bot " + "asdffdsa", 12345)
 
 	def test_banroute_get_collection__no_elements(self):
-		result = BanRoute().get_collection(self.session, "Bot " + BOT_TOKEN, self.serverid)
+		result = BanRoute().get_collection(self.session, self.authtoken, self.serverid)
 		self.assertEqual(result, [])
 
 	def test_banroute_get_collection__one_element(self):
@@ -67,15 +68,16 @@ class TestBanRouteGetCollection(TestCase):
 class TestBanRouteGetCollection(TestCase):
 	def setUp(self):
 		db.Model.metadata.create_all(engine)
+		self.authtoken = "Bot " + BOT_TOKEN
 		self.connection = engine.connect()
 		self.trans = self.connection.begin()
 		self.session = Session(bind=self.connection)
 
 	def test_banroute_get_one__bad_serverid(self):
-		self.assertRaises(InvalidTypeError, BanRoute().get_one, self.session, "Bot " + BOT_TOKEN, "asdf")
+		self.assertRaises(InvalidTypeError, BanRoute().get_one, self.session, self.authtoken, "asdf")
 
 	def test_banroute_get_one__not_found(self):
-		self.assertRaises(NotFoundError, BanRoute().get_one, self.session, "Bot " + BOT_TOKEN, "0")
+		self.assertRaises(NotFoundError, BanRoute().get_one, self.session, self.authtoken, "0")
 
 	def test_banroute_get_one__unauthorized(self):
 		self.assertRaises(AuthenticationError, BanRoute().get_one, self.session, "Bot " + "asdffdsa", "0")
@@ -98,6 +100,7 @@ class TestBanRoutePostCollection(TestCase):
 	def setUp(self):
 		db.Model.metadata.create_all(engine)
 		self.connection = engine.connect()
+		self.authtoken = "Bot " + BOT_TOKEN
 		self.trans = self.connection.begin()
 		self.session = Session(bind=self.connection)
 		self.serverid = "1234"
@@ -106,12 +109,18 @@ class TestBanRoutePostCollection(TestCase):
 
 	def test_banroute_post_collection__good_request(self):
 		banned_word = "asdf"
-		result = BanRoute().post_collection(self.session, "Bot " + BOT_TOKEN, self.serverid, banned_word)
+		result = BanRoute().post_collection(self.session, self.authtoken, self.serverid, banned_word)
 		db_result = self.session.query(Ban).filter_by(server_id=self.serverid, banned_word=banned_word).first()
 		self.assertEqual(result,db_result.to_dict())
 
+	def test_banroute_post_collection__too_many_words(self):
+		BanRoute().post_collection(self.session, self.authtoken, self.serverid, "asdf")
+		BanRoute().post_collection(self.session, self.authtoken, self.serverid, "sdfa")
+		BanRoute().post_collection(self.session, self.authtoken, self.serverid, "dfas")
+		self.assertRaises(ValidationError, BanRoute().post_collection, self.session, self.authtoken, self.serverid, "fasd")
+
 	def test_banroute_post_collection__server_not_found(self):
-		self.assertRaises(NotFoundError, BanRoute().post_collection, self.session, "Bot " + BOT_TOKEN, "4321", "asdf")
+		self.assertRaises(NotFoundError, BanRoute().post_collection, self.session, self.authtoken, "4321", "asdf")
 
 	def test_banroute_post_collection__unauthorized(self):
 		self.assertRaises(AuthenticationError, BanRoute().post_collection, self.session, "Bot " + "asdffdsa", self.serverid, "asdf")
@@ -119,11 +128,11 @@ class TestBanRoutePostCollection(TestCase):
 	def test_banroute_post_collection__duplicate_word(self):
 		banned_word = "asdf"
 		BanRoute().post_collection(self.session, "Bot " + BOT_TOKEN, self.serverid, banned_word)
-		self.assertRaises(DuplicateResourceError, BanRoute().post_collection, self.session, "Bot " + BOT_TOKEN, self.serverid, banned_word)
+		self.assertRaises(DuplicateResourceError, BanRoute().post_collection, self.session, self.authtoken, self.serverid, banned_word)
 
 	def test_banroute_post_collection__invalid_word(self):
 		banned_word = 1234
-		self.assertRaises(InvalidTypeError, BanRoute().post_collection, self.session, "Bot " + BOT_TOKEN, self.serverid, banned_word)
+		self.assertRaises(InvalidTypeError, BanRoute().post_collection, self.session, self.authtoken, self.serverid, banned_word)
 
 	def tearDown(self):
 		self.session.close()
@@ -136,9 +145,9 @@ class TestBanRoutePostOne(TestCase):
 		self.connection = engine.connect()
 		self.trans = self.connection.begin()
 		self.session = Session(bind=self.connection)
-		serverid = 1234
-		new_ban = Ban(server_id=serverid, banned_word="asdf", infracted_at=(datetime.now()-timedelta(days=6)).strftime("%Y-%m-%d %H:%M:%S"))
-		new_server = Server(server_id=serverid, banned_words=[new_ban])
+		self.serverid = 1234
+		new_ban = Ban(server_id=self.serverid, banned_word="asdf", infracted_at=(datetime.now()-timedelta(days=6)).strftime("%Y-%m-%d %H:%M:%S"))
+		new_server = Server(server_id=self.serverid, banned_words=[new_ban])
 		self.session.add(new_server)
 
 	def test_banroute_post_one__good_request(self):
@@ -149,20 +158,20 @@ class TestBanRoutePostOne(TestCase):
 		old_time = ban.infracted_at
 		self.assertNotEqual(new_word, ban.banned_word)
 
-		BanRoute().post_one(self.session, "Bot " + BOT_TOKEN, banid, new_word)
+		BanRoute().post_one(self.session, "Bot " + BOT_TOKEN, self.serverid, banid, new_word)
 		self.assertEqual(new_word, BanRoute().get_one(self.session, "Bot " + BOT_TOKEN, banid)['banned_word'])
 		self.assertEqual(True,\
 			datetime.strptime(ban.infracted_at, "%Y-%m-%d %H:%M:%S") >\
 			datetime.strptime(old_time, "%Y-%m-%d %H:%M:%S"))
 
 	def test_banroute_post_one__ban_not_found(self):
-		self.assertRaises(NotFoundError, BanRoute().post_one, self.session, "Bot " + BOT_TOKEN, 5, "asdf")
+		self.assertRaises(NotFoundError, BanRoute().post_one, self.session, "Bot " + BOT_TOKEN, self.serverid, 5, "asdf")
 
 	def test_banroute_post_one__unauthorized(self):
-		self.assertRaises(AuthenticationError, BanRoute().post_one, self.session, "Bot " + "asdffdsa", 5, "asdf")
+		self.assertRaises(AuthenticationError, BanRoute().post_one, self.session, "Bot " + "asdffdsa", self.serverid, 5, "asdf")
 
 	def test_banroute_post_one__word_invalid(self):
-		self.assertRaises(InvalidTypeError, BanRoute().post_one, self.session, "Bot " + BOT_TOKEN, 1, 1234)
+		self.assertRaises(InvalidTypeError, BanRoute().post_one, self.session, "Bot " + BOT_TOKEN, self.serverid, 1, 1234)
 
 	def tearDown(self):
 		self.session.close()
@@ -185,21 +194,26 @@ class TestBanRouteDelete(TestCase):
 	def test_banroute_delete__good_request(self):
 		banid = 1
 
-		BanRoute().delete(self.session, "Bot " + BOT_TOKEN, banid)
+		BanRoute().delete(self.session, "Bot " + BOT_TOKEN, self.serverid, banid)
 		self.assertRaises(NotFoundError, BanRoute().get_one, self.session, "Bot " + BOT_TOKEN, banid)
 		server_words = self.session.query(Server).filter_by(server_id=self.serverid).first().banned_words
 		self.assertEqual(len(server_words), 2)
 
 	def test_banroute_delete__ban_not_found(self):
-		self.assertRaises(NotFoundError, BanRoute().delete, self.session, "Bot " + BOT_TOKEN, 5)
+		self.assertRaises(NotFoundError, BanRoute().delete, self.session, "Bot " + BOT_TOKEN, self.serverid, 5)
 
 	def test_banroute_delete__unauthorized(self):
-		self.assertRaises(AuthenticationError, BanRoute().delete, self.session, "Bot " + "asdffdsa", 1)
+		self.assertRaises(AuthenticationError, BanRoute().delete, self.session, "Bot " + "asdffdsa", self.serverid, 1)
 
 	def test_banroute_delete__twice(self):
 		banid = 1
-		BanRoute().delete(self.session, "Bot " + BOT_TOKEN, banid)
-		self.assertRaises(NotFoundError, BanRoute().delete, self.session, "Bot " + BOT_TOKEN, banid)
+		BanRoute().delete(self.session, "Bot " + BOT_TOKEN, self.serverid, banid)
+		self.assertRaises(NotFoundError, BanRoute().delete, self.session, "Bot " + BOT_TOKEN, self.serverid, banid)
+
+	def test_banroute_delete__delete_last_word(self):
+		BanRoute().delete(self.session, "Bot " + BOT_TOKEN, self.serverid, 1)
+		BanRoute().delete(self.session, "Bot " + BOT_TOKEN, self.serverid, 3)
+		self.assertRaises(ValidationError, BanRoute().delete, self.session, "Bot " + BOT_TOKEN, self.serverid, 2)
 
 	def tearDown(self):
 		self.session.close()


### PR DESCRIPTION
Pre-amble to letting users ban multiple things. They now can't ban more
than 3 words, and can't delete all of their banned words.