### PR TITLE
Updated dupe ban check

### DIFF
--- a/bannedWordServer/router.py
+++ b/bannedWordServer/router.py
@@ -1,7 +1,7 @@
 from flask import jsonify, request
 
 from bannedWordServer import app, db
-from bannedWordServer.constants.errors import NotFoundError, InvalidTypeError, ValidationError, AuthenticationError
+from bannedWordServer.constants.errors import NotFoundError, DuplicateResourceError, InvalidTypeError, ValidationError, AuthenticationError
 from bannedWordServer.models import Ban, Server
 from bannedWordServer.routes import BanRoute, MessageRoute, ServerRoute
 
@@ -11,6 +11,7 @@ def start_session():
 @app.errorhandler(AuthenticationError)
 @app.errorhandler(ValidationError)
 @app.errorhandler(InvalidTypeError)
+@app.errorhandler(DuplicateResourceError)
 @app.errorhandler(NotFoundError)
 def handle_error(error):
 	response = jsonify()

--- a/bannedWordServer/routes/banroute.py
+++ b/bannedWordServer/routes/banroute.py
@@ -1,3 +1,4 @@
+from confusables import is_confusable
 from datetime import datetime, timedelta
 
 from bannedWordServer.constants.errors import ValidationError, DuplicateResourceError, NotFoundError, InvalidTypeError, AuthenticationError
@@ -43,7 +44,7 @@ class BanRoute(Resource):
 		if len(server_to_modify.banned_words) == 3:
 			raise ValidationError
 
-		already_exists = session.query(Ban).filter_by(server_id=serverid, banned_word=banned_word).first()
+		already_exists = any([is_confusable(banned_word, ban.banned_word) for ban in server_to_modify.banned_words])
 		if already_exists: raise DuplicateResourceError
 
 		new_ban = Ban(server_id=serverid,
@@ -66,6 +67,9 @@ class BanRoute(Resource):
 		if not server_to_modify: raise NotFoundError
 		ban = session.query(Ban).filter_by(server_id=serverid, rowid=banid).first()
 		if not ban:	raise NotFoundError
+
+		already_exists = any([is_confusable(banned_word, ban.banned_word) for ban in server_to_modify.banned_words])
+		if already_exists: raise DuplicateResourceError
 
 		ban.banned_word = banned_word
 		ban.infracted_at = datetime.now().strftime("%Y-%m-%d %H:%M:%S")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 Click==7.0
+confusables==1.1.1
 Flask==1.1.1
 Flask-Cors==3.0.8
 Flask-SQLAlchemy==2.4.1

--- a/tests/routes/test_banroute.py
+++ b/tests/routes/test_banroute.py
@@ -130,6 +130,10 @@ class TestBanRoutePostCollection(TestCase):
 		BanRoute().post_collection(self.session, "Bot " + BOT_TOKEN, self.serverid, banned_word)
 		self.assertRaises(DuplicateResourceError, BanRoute().post_collection, self.session, self.authtoken, self.serverid, banned_word)
 
+	def test_banroute_post_collection__confusable_word(self):
+		BanRoute().post_collection(self.session, "Bot " + BOT_TOKEN, self.serverid, 'lest')
+		self.assertRaises(DuplicateResourceError, BanRoute().post_collection, self.session, self.authtoken, self.serverid, 'iest')
+
 	def test_banroute_post_collection__invalid_word(self):
 		banned_word = 1234
 		self.assertRaises(InvalidTypeError, BanRoute().post_collection, self.session, self.authtoken, self.serverid, banned_word)
@@ -166,6 +170,10 @@ class TestBanRoutePostOne(TestCase):
 
 	def test_banroute_post_one__ban_not_found(self):
 		self.assertRaises(NotFoundError, BanRoute().post_one, self.session, "Bot " + BOT_TOKEN, self.serverid, 5, "asdf")
+
+	def test_banroute_post_one__confusable_word(self):
+		BanRoute().post_collection(self.session, "Bot " + BOT_TOKEN, self.serverid, 'lest')
+		self.assertRaises(DuplicateResourceError, BanRoute().post_one, self.session, "Bot " + BOT_TOKEN, self.serverid, 1, "iest")
 
 	def test_banroute_post_one__unauthorized(self):
 		self.assertRaises(AuthenticationError, BanRoute().post_one, self.session, "Bot " + "asdffdsa", self.serverid, 5, "asdf")


### PR DESCRIPTION
Instead of checking if the literal string is already banned, we check if
it's confusable for any existing banned word.