### PR TITLE
Fixes prod mode

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -3,7 +3,9 @@ import os
 
 from bannedWordServer.router import app
 
-if os.environ['DEVELOPMENT_MODE']:
+if 'DEVELOPMENT_MODE' in os.environ:
 	app.run(host='0.0.0.0')
 else:
-	serve(app)
+	serve(app, threads=int(os.environ['WAITRESS_THREAD_COUNT']))
+
+


### PR DESCRIPTION
The check to see if we were in dev mode was incorrect. It is now
considered to be in development mode if the `DEVELOPMENT_MODE`
environment variable is present.

Also "fixes" an issue where tasks would get queued up and cause the
bot to die, by making the thread_count an environment variable.