### PR TITLE
Prevents over-long timers being submitted

### DIFF
--- a/bannedWordServer/routes/serverroute.py
+++ b/bannedWordServer/routes/serverroute.py
@@ -1,7 +1,7 @@
 from datetime import datetime, timedelta
 
 from bannedWordServer.auth import authenticateBotOnly
-from bannedWordServer.constants.errors import NotFoundError, InvalidTypeError, DuplicateResourceError, AuthenticationError
+from bannedWordServer.constants.errors import NotFoundError, InvalidTypeError, DuplicateResourceError, AuthenticationError, ValidationError
 from bannedWordServer.models.server import Server
 from bannedWordServer.models.ban import Ban
 from bannedWordServer.routes.resource import Resource
@@ -59,6 +59,7 @@ class ServerRoute(Resource):
 		if 'timeout_duration_seconds' in modified_params.keys():
 			timeout_duration_seconds: int = modified_params['timeout_duration_seconds']
 			if not isinstance(timeout_duration_seconds, int): raise InvalidTypeError
+			if timeout_duration_seconds >= 100000000: raise ValidationError
 			server_to_modify.timeout_duration_seconds = timeout_duration_seconds
 
 		return self.get_one(session, authToken, serverid)

--- a/tests/routes/test_serverroute.py
+++ b/tests/routes/test_serverroute.py
@@ -4,7 +4,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker
 from unittest import TestCase
 
-from bannedWordServer.constants.errors import NotFoundError, InvalidTypeError, DuplicateResourceError, AuthenticationError
+from bannedWordServer.constants.errors import NotFoundError, InvalidTypeError, DuplicateResourceError, AuthenticationError, ValidationError
 from bannedWordServer import db
 from bannedWordServer.models.server import Server
 from bannedWordServer.models.ban import Ban
@@ -157,6 +157,16 @@ class TestServerRoutePartialUpdate(TestCase):
 
 		ServerRoute().partial_update(self.session, "Bot " + BOT_TOKEN, self.serverid, update_params)
 		self.assertEqual(update_params['timeout_duration_seconds'],\
+						ServerRoute().get_one(self.session, "Bot " + BOT_TOKEN, self.serverid)['timeout_duration_seconds'])
+
+	def test_serverroute_partial_update__update_timeout_duration_too_long(self):
+		update_params = {'timeout_duration_seconds': 777777777777777}
+
+		self.assertNotEqual(update_params['timeout_duration_seconds'],\
+						ServerRoute().get_one(self.session, "Bot " + BOT_TOKEN, self.serverid)['timeout_duration_seconds'])
+
+		self.assertRaises(ValidationError, ServerRoute().partial_update, self.session, "Bot " + BOT_TOKEN, self.serverid, update_params)
+		self.assertNotEqual(update_params['timeout_duration_seconds'],\
 						ServerRoute().get_one(self.session, "Bot " + BOT_TOKEN, self.serverid)['timeout_duration_seconds'])
 
 	def test_serverroute_partial_update__update_all(self):


### PR DESCRIPTION
If a request is submitted that attempts to set a timeout_duration
to over 200 million seconds, it now raises a ValidationError