### PR TITLE
Adds per-user infraction tracking

### DIFF
--- a/bannedWordServer/models/__init__.py
+++ b/bannedWordServer/models/__init__.py
@@ -6,4 +6,12 @@ from .ban_record import BanRecord
 from .plan import Plan
 from .server_plan import ServerPlan
 
-__all__ = ["Author", "Ban", "BanRecord", "Plan", "Server", "ServerPlan"]
+__all__ = [
+    "Author",
+    "AuthorInfraction",
+    "Ban",
+    "BanRecord",
+    "Plan",
+    "Server",
+    "ServerPlan"
+]

--- a/bannedWordServer/models/__init__.py
+++ b/bannedWordServer/models/__init__.py
@@ -1,7 +1,9 @@
+from .author import Author
+from .author_infraction import AuthorInfraction
 from .ban import Ban
 from .server import Server
 from .ban_record import BanRecord
 from .plan import Plan
 from .server_plan import ServerPlan
 
-__all__ = ["Ban", "BanRecord", "Plan", "Server", "ServerPlan"]
+__all__ = ["Author", "Ban", "BanRecord", "Plan", "Server", "ServerPlan"]

--- a/bannedWordServer/models/author.py
+++ b/bannedWordServer/models/author.py
@@ -1,0 +1,31 @@
+from datetime import datetime
+
+from bannedWordServer import db
+
+def current_time():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+class Author(db.Model):
+    __tablename__ = "author"
+
+    user_id = db.Column(db.Integer, primary_key=True)
+    infraction_count = db.Column(db.Integer, nullable=False, default=0)
+    created_at = db.Column(
+        db.String, nullable=False, default=datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
+    updated_at = db.Column(
+        db.String,
+        nullable=False,
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        onupdate=current_time,
+    )
+    infractions = db.relationship("AuthorInfraction")
+
+    def to_dict(self):
+        entry = {}
+        entry["user_id"] = self.user_id
+        entry["incraction_count"] = self.infraction_count
+        entry["updated_at"] = self.updated_at
+        entry["infractions"] = [infraction.to_dict() for infraction in self.infractions]
+
+        return entry

--- a/bannedWordServer/models/author.py
+++ b/bannedWordServer/models/author.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 from bannedWordServer import db
 
+
 def current_time():
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
 
 class Author(db.Model):
     __tablename__ = "author"

--- a/bannedWordServer/models/author_infraction.py
+++ b/bannedWordServer/models/author_infraction.py
@@ -1,0 +1,41 @@
+from datetime import datetime
+
+from bannedWordServer import db
+
+def current_time():
+    return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
+class AuthorInfraction(db.Model):
+    __tablename__ = "author_infraction"
+
+    rowid = db.Column(db.Integer, primary_key=True)
+    user_id = db.Column(
+        db.Integer,
+        db.ForeignKey("author.user_id", onupdate="cascade"),
+        nullable=False,
+    )
+    ban_id = db.Column(
+        db.Integer,
+        db.ForeignKey("server_banned_word.rowid", onupdate="cascade"),
+        nullable=False,
+    )
+    infraction_count = db.Column(db.Integer, nullable=False, default=0)
+
+    created_at = db.Column(
+        db.String, nullable=False, default=datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+    )
+    updated_at = db.Column(
+        db.String,
+        nullable=False,
+        default=datetime.now().strftime("%Y-%m-%d %H:%M:%S"),
+        onupdate=current_time,
+    )
+
+    def to_dict(self):
+        entry = {}
+        entry["user_id"] = self.user_id
+        entry["ban_id"] = self.ban_id
+        entry["incraction_count"] = self.infraction_count
+        entry["updated_at"] = self.updated_at
+
+        return entry

--- a/bannedWordServer/models/author_infraction.py
+++ b/bannedWordServer/models/author_infraction.py
@@ -2,8 +2,10 @@ from datetime import datetime
 
 from bannedWordServer import db
 
+
 def current_time():
     return datetime.now().strftime("%Y-%m-%d %H:%M:%S")
+
 
 class AuthorInfraction(db.Model):
     __tablename__ = "author_infraction"

--- a/bannedWordServer/routes/messageroute.py
+++ b/bannedWordServer/routes/messageroute.py
@@ -53,9 +53,16 @@ class MessageRoute(Resource):
         else:
             user_to_modify.infraction_count += 1
 
-        author_inf_to_modify = session.query(AuthorInfraction).filter_by(user_id=authorid, ban_id=banid).first()
+        author_inf_to_modify = session \
+            .query(AuthorInfraction) \
+            .filter_by(user_id=authorid, ban_id=banid) \
+            .first()
         if not author_inf_to_modify:
-            new_infraction = AuthorInfraction(user_id=authorid, ban_id=banid, infraction_count=1)
+            new_infraction = AuthorInfraction(
+                    user_id=authorid,
+                    ban_id=banid,
+                    infraction_count=1
+                )
             session.add(new_infraction)
         else:
             author_inf_to_modify.infraction_count += 1

--- a/bannedWordServer/routes/messageroute.py
+++ b/bannedWordServer/routes/messageroute.py
@@ -2,7 +2,7 @@ import re
 from datetime import datetime
 
 from bannedWordServer.auth import authenticateBotOnly
-from bannedWordServer.models import Ban, BanRecord
+from bannedWordServer.models import Author, AuthorInfraction, Ban, BanRecord
 from bannedWordServer.routes.resource import Resource
 from bannedWordServer.constants.errors import (
     NotFoundError,
@@ -30,6 +30,11 @@ class MessageRoute(Resource):
         except ValueError:
             raise InvalidTypeError
 
+        try:
+            authorid = int(requestJson["author_id"])
+        except ValueError:
+            raise InvalidTypeError
+
         ban_to_modify = session.query(Ban).filter_by(rowid=banid).first()
         record_to_modify = session.query(BanRecord).filter_by(ban_id=banid).first()
         if not ban_to_modify or not record_to_modify:
@@ -39,6 +44,21 @@ class MessageRoute(Resource):
             raise InvalidTypeError
         if not self.pattern.match(requestJson["sent_time"]):
             raise ValidationError
+
+        user_to_modify = session.query(Author).filter_by(user_id=authorid).first()
+        if not user_to_modify:
+            new_user = Author(user_id=authorid, infraction_count=1)
+            session.add(new_user)
+            user_to_modify = session.query(Author).filter_by(user_id=authorid).first()
+        else:
+            user_to_modify.infraction_count += 1
+
+        author_inf_to_modify = session.query(AuthorInfraction).filter_by(user_id=authorid, ban_id=banid).first()
+        if not author_inf_to_modify:
+            new_infraction = AuthorInfraction(user_id=authorid, ban_id=banid, infraction_count=1)
+            session.add(new_infraction)
+        else:
+            author_inf_to_modify.infraction_count += 1
 
         diff_in_seconds = (
             datetime.strptime(requestJson["sent_time"], "%Y-%m-%d %H:%M:%S")

--- a/migrations/2021-05-26-1-author-table.sql
+++ b/migrations/2021-05-26-1-author-table.sql
@@ -1,0 +1,18 @@
+CREATE TABLE 'author' (
+    user_id int NOT NULL PRIMARY KEY,
+    infraction_count int DEFAULT 0,
+    created_at Varchar NOT NULL,
+    updated_at Varchar DEFAULT CURRENT_TIMESTAMP
+);
+
+CREATE TABLE 'author_infraction' (
+    user_id int NOT NULL,
+    ban_id int NOT NULL,
+    infraction_count int DEFAULT 0,
+    created_at Varchar NOT NULL,
+    updated_at Varchar DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY(user_id, ban_id),
+    FOREIGN KEY(ban_id) REFERENCES server_banned_word(rowid),
+    FOREIGN KEY(user_id) REFERENCES server_banned_word(user_id)
+
+);

--- a/tests/routes/test_messageroute.py
+++ b/tests/routes/test_messageroute.py
@@ -12,7 +12,7 @@ from bannedWordServer.constants.errors import (
     AuthenticationError,
 )
 from bannedWordServer import db
-from bannedWordServer.models import Ban, BanRecord, Server
+from bannedWordServer.models import Ban, BanRecord, Server, Author, AuthorInfraction
 from bannedWordServer.routes.messageroute import MessageRoute
 
 Session = sessionmaker()
@@ -49,6 +49,7 @@ class TestBanRoutePostOne(TestCase):
     def test_messageroute_post__ban_not_found(self):
         request = {
             "ban_id": 3,
+            "author_id": 1,
             "sent_time": self.current_time_string,
         }
         self.assertRaises(
@@ -62,6 +63,7 @@ class TestBanRoutePostOne(TestCase):
     def test_messageroute_post__unauthorized(self):
         request = {
             "ban_id": 3,
+            "author_id": 1,
             "sent_time": self.current_time_string,
         }
         self.assertRaises(
@@ -75,6 +77,7 @@ class TestBanRoutePostOne(TestCase):
     def test_messageroute_post__good_request(self):
         request = {
             "ban_id": 1,
+            "author_id": 1,
             "sent_time": self.current_time_string,
         }
         self.assertNotEqual(
@@ -93,10 +96,62 @@ class TestBanRoutePostOne(TestCase):
         self.assertEqual(
             1, self.session.query(BanRecord).filter_by(rowid=1).first().infraction_count
         )
+    
+    def test_messageroute_post__new_author(self):
+        request = {
+            "ban_id": 1,
+            "author_id": 1,
+            "sent_time": self.current_time_string,
+        }
+        MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
+        self.assertEqual(
+            1,
+            self.session.query(Author).filter_by(user_id=1).first().infraction_count
+        )
+        self.assertEqual(
+            1,
+            self.session.query(AuthorInfraction).filter_by(user_id=1, ban_id=1).first().infraction_count
+        )
+
+    def test_messageroute_post__existing_author_new_infraction(self):
+        new_author = Author(user_id=1, infraction_count=9)
+        self.session.add(new_author)
+        request = {
+            "ban_id": 1,
+            "author_id": 1,
+            "sent_time": self.current_time_string,
+        }
+        MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
+        self.assertEqual(
+            10,
+            self.session.query(Author).filter_by(user_id=1).first().infraction_count
+        )
+        self.assertEqual(
+            1,
+            self.session.query(AuthorInfraction).filter_by(user_id=1, ban_id=1).first().infraction_count
+        )
+
+    def test_messageroute_post__existing_author_and_infraction(self):
+        new_author = Author(user_id=1, infraction_count=9)
+        new_authinf = AuthorInfraction(user_id=1, ban_id=1, infraction_count=2)
+        self.session.add(new_author)
+        self.session.add(new_authinf)
+
+        request = {
+            "ban_id": 1,
+            "author_id": 1,
+            "sent_time": self.current_time_string,
+        }
+        MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
+        self.assertEqual(
+            3,
+            self.session.query(AuthorInfraction).filter_by(user_id=1, ban_id=1).first().infraction_count
+        )
 
     def test_messageroute_post__record_setting(self):
         request = {
             "ban_id": 1,
+            "author_id": 1,
             "sent_time": self.current_time_string,
         }
         MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
@@ -108,6 +163,7 @@ class TestBanRoutePostOne(TestCase):
     def test_messageroute_post__non_record_setting(self):
         request = {
             "ban_id": 1,
+            "author_id": 1,
             "sent_time": self.current_time_string,
         }
         self.assertNotEqual(
@@ -124,6 +180,7 @@ class TestBanRoutePostOne(TestCase):
     def test_messageroute_post__good_request_callout(self):
         request = {
             "ban_id": 1,
+            "author_id": 1,
             "sent_time": self.current_time_string,
             "called_out": True,
         }
@@ -149,6 +206,7 @@ class TestBanRoutePostOne(TestCase):
     def test_messageroute_post__invalid_paras(self):
         request = {
             "ban_id": "asdf",
+            "author_id": 1,
             "sent_time": self.current_time_string,
             "called_out": True,
         }
@@ -160,7 +218,7 @@ class TestBanRoutePostOne(TestCase):
             request,
         )
 
-        request = {"ban_id": 1, "sent_time": 1234, "called_out": True}
+        request = {"ban_id": 1, "sent_time": 1234, "author_id": 1, "called_out": True}
         self.assertRaises(
             InvalidTypeError,
             MessageRoute().post,
@@ -169,7 +227,7 @@ class TestBanRoutePostOne(TestCase):
             request,
         )
 
-        request = {"ban_id": 1, "sent_time": "asdf", "called_out": True}
+        request = {"ban_id": 1, "sent_time": "asdf", "author_id": 1, "called_out": True}
         self.assertRaises(
             ValidationError,
             MessageRoute().post,
@@ -178,6 +236,14 @@ class TestBanRoutePostOne(TestCase):
             request,
         )
 
+        request = {"ban_id": 1, "sent_time": self.current_time_string, "author_id": "asdf", "called_out": True}
+        self.assertRaises(
+            ValidationError,
+            MessageRoute().post,
+            self.session,
+            "Bot " + BOT_TOKEN,
+            request,
+        )
     def tearDown(self):
         self.session.close()
         self.trans.rollback()

--- a/tests/routes/test_messageroute.py
+++ b/tests/routes/test_messageroute.py
@@ -96,7 +96,7 @@ class TestBanRoutePostOne(TestCase):
         self.assertEqual(
             1, self.session.query(BanRecord).filter_by(rowid=1).first().infraction_count
         )
-    
+
     def test_messageroute_post__new_author(self):
         request = {
             "ban_id": 1,
@@ -110,7 +110,11 @@ class TestBanRoutePostOne(TestCase):
         )
         self.assertEqual(
             1,
-            self.session.query(AuthorInfraction).filter_by(user_id=1, ban_id=1).first().infraction_count
+            self.session
+                .query(AuthorInfraction)
+                .filter_by(user_id=1, ban_id=1)
+                .first()
+                .infraction_count
         )
 
     def test_messageroute_post__existing_author_new_infraction(self):
@@ -124,11 +128,19 @@ class TestBanRoutePostOne(TestCase):
         MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
         self.assertEqual(
             10,
-            self.session.query(Author).filter_by(user_id=1).first().infraction_count
+            self.session
+                .query(Author)
+                .filter_by(user_id=1)
+                .first()
+                .infraction_count
         )
         self.assertEqual(
             1,
-            self.session.query(AuthorInfraction).filter_by(user_id=1, ban_id=1).first().infraction_count
+            self.session
+                .query(AuthorInfraction)
+                .filter_by(user_id=1, ban_id=1)
+                .first()
+                .infraction_count
         )
 
     def test_messageroute_post__existing_author_and_infraction(self):
@@ -145,7 +157,11 @@ class TestBanRoutePostOne(TestCase):
         MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
         self.assertEqual(
             3,
-            self.session.query(AuthorInfraction).filter_by(user_id=1, ban_id=1).first().infraction_count
+            self.session
+                .query(AuthorInfraction)
+                .filter_by(user_id=1, ban_id=1)
+                .first()
+                .infraction_count
         )
 
     def test_messageroute_post__record_setting(self):
@@ -157,7 +173,11 @@ class TestBanRoutePostOne(TestCase):
         MessageRoute().post(self.session, "Bot " + BOT_TOKEN, request)
         self.assertEqual(
             timedelta(days=6).total_seconds(),
-            self.session.query(BanRecord).filter_by(rowid=1).first().record_seconds,
+            self.session
+                .query(BanRecord)
+                .filter_by(rowid=1)
+                .first()
+                .record_seconds
         )
 
     def test_messageroute_post__non_record_setting(self):
@@ -236,7 +256,13 @@ class TestBanRoutePostOne(TestCase):
             request,
         )
 
-        request = {"ban_id": 1, "sent_time": self.current_time_string, "author_id": "asdf", "called_out": True}
+        request = {
+            "ban_id": 1,
+            "sent_time": self.current_time_string,
+            "author_id": "asdf",
+            "called_out": True
+        }
+
         self.assertRaises(
             ValidationError,
             MessageRoute().post,
@@ -244,6 +270,7 @@ class TestBanRoutePostOne(TestCase):
             "Bot " + BOT_TOKEN,
             request,
         )
+
     def tearDown(self):
         self.session.close()
         self.trans.rollback()


### PR DESCRIPTION
By popular request, we now track both how many times a user has annoyed
the bot, and how many times they've infracted against any particular ban.

Nifty.

There's no way to see this data beyond directly pinging the database as of yet, but it'll at least start tracking it.